### PR TITLE
Update to yew 0.23, bump crate to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "split-yew"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Yew component for the Split.js library: a resizable split view for web apps."
 authors = ["Alessandro Balducci <aleb2000@hotmail.com>"]
@@ -16,4 +16,4 @@ js-sys = "0.3.64"
 regex = "1.9.3"
 wasm-bindgen = "0.2.87"
 web-sys = "0.3.64"
-yew = "0.22"
+yew = "0.23"

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 [docsrs-url]: https://docs.rs/split-yew/
 [license-badge]: https://img.shields.io/github/license/aleb2000/split-yew
 [license-url]: https://github.com/aleb2000/split-yew/blob/main/LICENSE-MIT
-[yew-badge]: https://img.shields.io/badge/yew-0.21-009a5b
-[yew-url]: https://crates.io/crates/yew/0.21.0
+[yew-badge]: https://img.shields.io/badge/yew-0.23-009a5b
+[yew-url]: https://crates.io/crates/yew/0.23.0
 
 
 This library adds a Yew component wrapper for the [Split.js library](https://split.js.org/). Similar to the [react-split](https://github.com/nathancahill/split/tree/master/packages/react-split) component.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ impl Component for Split {
         } = ctx.props();
 
         html! {
-            <div class={(*class).clone()} ref={self.parent_ref.clone()}>
+            <div class={class.clone()} ref={self.parent_ref.clone()}>
                 { for children.iter() }
             </div>
         }


### PR DESCRIPTION
The breaking change is not directly relevant to split-yew.

https://github.com/yewstack/yew/releases/tag/yew-v0.23.0

But bumping to 0.4.0 is still correct since it is a breaking change for downstream users of split-yew and they must also upgrade yew.